### PR TITLE
Update README badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Danger Modules Report
 
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Jacoco](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSebVay%2FCI-CD-Badges%2Frefs%2Fheads%2Fmain%2Fdanger-modules-report%2Fbadges%2Fcoverage.json)](https://sebvay.github.io/CI-CD-Badges/danger-modules-report/jacoco/test/html/index.html)
+[![Jacoco](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/SebVay/CI-CD-Badges/refs/heads/main/Multi-Module-Report/badges/coverage.json)](https://sebvay.github.io/CI-CD-Badges/Multi-Module-Report/)
 
 Generate [beautiful and attractive](https://github.com/SebVay/Multi-Module-Report/pull/1), modules report 
 on your Pull Requests using Github Actions or [Danger Kotlin](https://danger.systems/kotlin/).

--- a/multi-module-report-danger/README.md
+++ b/multi-module-report-danger/README.md
@@ -1,0 +1,1 @@
+[![Jacoco](https://raw.githubusercontent.com/SebVay/CI-CD-Badges/refs/heads/main/Multi-Module-Report/multi-module-report-danger/badges/coverage.json)](https://sebvay.github.io/CI-CD-Badges/Multi-Module-Report/)

--- a/multi-module-report/README.md
+++ b/multi-module-report/README.md
@@ -1,0 +1,1 @@
+[![Jacoco](https://raw.githubusercontent.com/SebVay/CI-CD-Badges/refs/heads/main/Multi-Module-Report/multi-module-report/badges/coverage.json)](https://sebvay.github.io/CI-CD-Badges/Multi-Module-Report/)


### PR DESCRIPTION
Some work has been done in CI impacting the https://github.com/SebVay/CI-CD-Badges side.
Now, the project has multiple modules, so I needed to improve the CI-CD-Badges project by centralizing the code-coverage reports in a same page, with redirections.
This PR just updates the path of the code coverage badges to reflect those changes.

See the [Code coverage report page](https://sebvay.github.io/CI-CD-Badges/Multi-Module-Report/).